### PR TITLE
lib-test: remove trap in failure

### DIFF
--- a/lib-test.sh
+++ b/lib-test.sh
@@ -7,6 +7,7 @@ success() {
 
 failure() {
     printf "❌ \e[3;1;31m%s\e[0m\e[1;31m failed\e[0m\n" "$1" >&2
+    trap - ERR EXIT # Remove the trap handler, so that it does not call itself
     exit 1
 }
 


### PR DESCRIPTION
Otherwise the `exit 1` would call itself