### PR TITLE
redeem-nuggit: do it with a git alias instead of directly calling a script

### DIFF
--- a/create_challenge.sh
+++ b/create_challenge.sh
@@ -60,7 +60,6 @@ Have a free nuggit!"
 mv ".git/refs/heads/$initial_branch" ".git/nuggits"
 
 cp -r "$DOCDIR/01_init/"* .
-cp "$DOCDIR/01_init/.gitignore" .
 git add .
 commit -m "Initial Commit"
 
@@ -149,11 +148,13 @@ ALMOST_CREDITS_HASH="$(git hash-object -w "$DOCDIR/almost_credits.txt")"
 # for the final credits do a little rot13, just to make life a bit harder if anyone e.g. greps through the loose objects...
 CREDITS_HASH="$(tr 'A-Za-z' 'N-ZA-Mn-za-m' < "$DOCDIR/credits.txt" | git hash-object -w --stdin)"
 
-replace_placeholders "$DOCDIR/redeem.nuggit" > ./redeem.nuggit
-chmod a=rx ./redeem.nuggit
+replace_placeholders "$DOCDIR/redeem.nuggit" > ./.git/redeem.nuggit
+chmod a=rx ./.git/redeem.nuggit
 
 # should be done as the last thing before installing the hooks
 remove_build_setup_from_config
+add_player_config
+
 # hooks (should be installed last, since they are self-mutating and would be called e.g. by `git commit`)
 rm .git/hooks/*
 

--- a/lib.sh
+++ b/lib.sh
@@ -51,6 +51,10 @@ remove_build_setup_from_config() {
     git config --local --remove-section user
 }
 
+add_player_config() {
+    git config --local --add alias.redeem-nuggit '!$(git rev-parse --show-toplevel)/.git/redeem.nuggit'
+}
+
 replace_placeholders() {
     sed -e "s/INTERACTIVE_REBASE_BASE_COMMIT/$INTERACTIVE_REBASE_BASE_COMMIT/" \
         -e "s/BRANCH_COMMIT/$BRANCH_COMMIT/" \

--- a/src/01_init/.gitignore
+++ b/src/01_init/.gitignore
@@ -1,1 +1,0 @@
-/redeem.nuggit

--- a/src/01_init/README.md
+++ b/src/01_init/README.md
@@ -12,7 +12,7 @@ Q: What is a nuggit?
 A: A nuggit is almost like a nugget a small golden piece, but with more git in it! It is a single word, e.g. "TestNuggit" and you will always find it in the format "nuggit: TestNuggit".
 
 Q: How to I redeem a nuggit?
-A: Just run `./redeem_nuggit <name of the nuggit>` - it will show you if you are correct or not.
+A: Just run `git redeem-nuggit <name of the nuggit>` - it will show you if you are correct or not. (No, redeem-nuggit is not a builtin git command, but an "alias" in this repository, we'll come to that later...)
 
 Q: Where do I see all my redeemed nuggits and the time when I redeemed them?
 A: Just run `git log nuggits` :)

--- a/test.sh
+++ b/test.sh
@@ -13,15 +13,15 @@ check_redeem_without_local_code_execution() {
     while read -r nuggit; do
         [ "$nuggit" != LocalCodeExecution ] || continue
         [ "$nuggit" != WorkInProgress ] || continue # we want to do this after all the others, so we see that this is the first time that the "You almost got it" text is shown
-        expect "./redeem.nuggit '$nuggit'" not to contain "You almost got it"
+        expect "git redeem-nuggit '$nuggit'" not to contain "You almost got it"
     done < "$DOCDIR/nuggits"
-    expect "./redeem.nuggit WorkInProgress" to contain "You almost got it! There is only a single nuggit left to redeem..."
-    expect "./redeem.nuggit WorkInProgress" to contain "You almost got it! There is only a single nuggit left to redeem..."
+    expect "git redeem-nuggit WorkInProgress" to contain "You almost got it! There is only a single nuggit left to redeem..."
+    expect "git redeem-nuggit WorkInProgress" to contain "You almost got it! There is only a single nuggit left to redeem..."
 }
 
 it 'LocalCodeExecution should be nonexistent/unredeamable after the trap got triggered' '
 git commit -am "Just a test to trigger hooks"
-expect "! ./redeem.nuggit LocalCodeExecution 2>&1" to contain "Unfortunately that is not a valid nuggit"
+expect "! git redeem-nuggit LocalCodeExecution 2>&1" to contain "Unfortunately that is not a valid nuggit"
 check_redeem_without_local_code_execution
 '
 
@@ -33,7 +33,7 @@ cd challenge
 reproducibility_setup
 
 redeem_nuggit() {
-    expect "./redeem.nuggit '$1'" to contain Success
+    expect "git redeem-nuggit '$1'" to contain Success
 }
 
 it 'LocalCodeExecution nuggit in hooks' '
@@ -97,21 +97,21 @@ expect 'eval "\$(get_sh_codeblock combine_history.md)"' to contain "FIXME TODO"
 EOF
 
 it 'An invalid nuggit should show an error' '
-expect "! ./redeem.nuggit NotANuggit 2>&1" to contain "Unfortunately that is not a valid nuggit"
-expect "! ./redeem.nuggit NotANuggit 2>&1" to contain "It still isn'\''t a valid answer..."
-expect "! ./redeem.nuggit NotANuggit 2>&1" to contain "It still isn'\''t a valid answer..."
+expect "! git redeem-nuggit NotANuggit 2>&1" to contain "Unfortunately that is not a valid nuggit"
+expect "! git redeem-nuggit NotANuggit 2>&1" to contain "It still isn'\''t a valid answer..."
+expect "! git redeem-nuggit NotANuggit 2>&1" to contain "It still isn'\''t a valid answer..."
 '
 
 it 'CuriosityKilledTheCat in redeem script' '
-expect "cat redeem.nuggit" to contain CuriosityKilledTheCat
+expect "cat .git/redeem.nuggit" to contain CuriosityKilledTheCat
 redeem_nuggit CuriosityKilledTheCat
 '
 
 check_redeem() {
     while read -r nuggit; do
-        expect "./redeem.nuggit '$nuggit'" to contain "You have found all the little nuggits?! Very impressive!"
-        expect "./redeem.nuggit '$nuggit'" to contain "already redeemed"
-        expect "./redeem.nuggit '$nuggit'" not to contain Success
+        expect "git redeem-nuggit '$nuggit'" to contain "You have found all the little nuggits?! Very impressive!"
+        expect "git redeem-nuggit '$nuggit'" to contain "already redeemed"
+        expect "git redeem-nuggit '$nuggit'" not to contain Success
     done < "$DOCDIR/nuggits"
 }
 


### PR DESCRIPTION
No need to call a script that is loosely flying around and captured by .gitignore...